### PR TITLE
Fix swiftlint.sh not handling space in file/folder names

### DIFF
--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -1,10 +1,13 @@
+OLD_IFS=$IFS
+IFS=$(echo -en "\n\b")
+
 count=0
 for file_path in $(git ls-files -om --exclude-from=.gitignore | grep ".swift$"); do
-    export SCRIPT_INPUT_FILE_$count=$file_path
+    export SCRIPT_INPUT_FILE_$count="$file_path"
     count=$((count + 1))
 done
 for file_path in $(git diff --cached --name-only | grep ".swift$"); do
-    export SCRIPT_INPUT_FILE_$count=$file_path
+    export SCRIPT_INPUT_FILE_$count="$file_path"
     count=$((count + 1))
 done
 
@@ -14,3 +17,5 @@ if (( $count > 0 )); then
     ${PODS_ROOT}/SwiftLint/swiftlint autocorrect --use-script-input-files
     ${PODS_ROOT}/SwiftLint/swiftlint lint --use-script-input-files
 fi
+
+IFS=$OLD_IFS


### PR DESCRIPTION
Perhaps better to do away with -ls-files but let's not waste time on that.