### PR TITLE
Realm integration tests

### DIFF
--- a/Jasmine.xcodeproj/project.pbxproj
+++ b/Jasmine.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		A2187E6E1E7511470033FC5B /* MutableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2187E6D1E7511470033FC5B /* MutableCollection+Extensions.swift */; };
 		A2187E721E751C930033FC5B /* Sequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2187E711E751C930033FC5B /* Sequence+Extensions.swift */; };
 		A260C6281E6AB30400782103 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A260C6271E6AB30400782103 /* Assets.xcassets */; };
+		A27B6E541E90B33400825AF3 /* RealmIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27B6E531E90B33400825AF3 /* RealmIntegrationTests.swift */; };
 		DF2052C81E8BDD5A00D66B0B /* UIImageView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2052C71E8BDD5A00D66B0B /* UIImageView+Animation.swift */; };
 		DF2155181E8E2335005A0927 /* PhrasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2155171E8E2335005A0927 /* PhrasesTests.swift */; };
 		DF21551A1E8E234D005A0927 /* Phrases.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2155191E8E234D005A0927 /* Phrases.swift */; };
@@ -133,6 +134,7 @@
 		A260C6271E6AB30400782103 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A260C6311E6AB30400782103 /* JasmineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JasmineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A260C6371E6AB30400782103 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A27B6E531E90B33400825AF3 /* RealmIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmIntegrationTests.swift; sourceTree = "<group>"; };
 		B0F92A417FF0A33A2C39DC68 /* Pods-JasmineUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JasmineUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JasmineUITests/Pods-JasmineUITests.release.xcconfig"; sourceTree = "<group>"; };
 		B1302F74452DAF05FDF7A169 /* Pods_JasmineTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_JasmineTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF6F46CAE49685937742BCB /* Pods-JasmineTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JasmineTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JasmineTests/Pods-JasmineTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -437,6 +439,7 @@
 				DF409FF41E84160C00389976 /* GameDataFactoryTests.swift */,
 				DF409FF61E84160C00389976 /* PlayerTests.swift */,
 				50AE3A771E8BE020005EC944 /* TextGridTests.swift */,
+				A27B6E531E90B33400825AF3 /* RealmIntegrationTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -970,6 +973,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DF409FEF1E8415E000389976 /* UIApplicationTests.swift in Sources */,
+				A27B6E541E90B33400825AF3 /* RealmIntegrationTests.swift in Sources */,
 				DF409FF21E8415F400389976 /* CountDownTimerTest.swift in Sources */,
 				50717AC31E7BD9D5005A2FE5 /* Sequence+ExtensionsTests.swift in Sources */,
 				50AE3A781E8BE020005EC944 /* TextGridTests.swift in Sources */,

--- a/JasmineTests/Common/Models/RealmIntegrationTests.swift
+++ b/JasmineTests/Common/Models/RealmIntegrationTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import Jasmine
+
+/// Unlike other tests that involves realm, this uses the real db to ensure it is usuable
+class RealmIntegrationTests: XCTestCase {
+
+    var factory: GameDataFactory!
+
+    override func setUp() {
+        super.setUp()
+        do {
+            factory = try GameDataFactory()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testRealm_phrases() {
+        let gameTypes: [GameType] = [.chengYu, .ciHui, .pinYin]
+        gameTypes.forEach { type in
+            let gameData = factory.createGame(difficulty: 1, type: .ciHui)
+            XCTAssertNotNil(gameData.phrases.next(), "Game data does not contain phrases")
+            XCTAssertEqual(gameData.phrases.next(count: 5).count, 5, "Incorrect amount of phrases")
+        }
+    }
+
+}

--- a/JasmineTests/Common/Models/RealmIntegrationTests.swift
+++ b/JasmineTests/Common/Models/RealmIntegrationTests.swift
@@ -18,7 +18,7 @@ class RealmIntegrationTests: XCTestCase {
     func testRealm_phrases() {
         let gameTypes: [GameType] = [.chengYu, .ciHui, .pinYin]
         gameTypes.forEach { type in
-            let gameData = factory.createGame(difficulty: 1, type: .ciHui)
+            let gameData = factory.createGame(difficulty: 1, type: type)
             XCTAssertNotNil(gameData.phrases.next(), "Game data does not contain phrases")
             XCTAssertEqual(gameData.phrases.next(count: 5).count, 5, "Incorrect amount of phrases")
         }


### PR DESCRIPTION
This uses the current realm file instead of in-memory replacement. Should prevent similar issues from occurring.