### PR TITLE
Round score properly

### DIFF
--- a/Jasmine/Sliding/ViewModels/BaseSlidingViewModel.swift
+++ b/Jasmine/Sliding/ViewModels/BaseSlidingViewModel.swift
@@ -95,7 +95,7 @@ class BaseSlidingViewModel: GridViewModel, SlidingViewModelProtocol {
 
         // In the sliding game, it is enough to have (rows - 1) rows correct
         if highlightedCoordinates.count == gridData.count - GameConstants.Sliding.columns {
-            score += max(Score.win + Int(timeRemaining * Score.multiplierFromTime) -
+            score += max(Score.win + Int(round(timeRemaining * Score.multiplierFromTime)) -
                 moves * Score.multiplierFromMoves, 0)
             gameStatus = .endedWithWon
         }

--- a/Jasmine/Swapping/ViewModels/BaseSwappingViewModel.swift
+++ b/Jasmine/Swapping/ViewModels/BaseSwappingViewModel.swift
@@ -55,7 +55,7 @@ class BaseSwappingViewModel: GridViewModel, SwappingViewModelProtocol {
         }
 
         if highlightedCoordinates.count == gridData.count {
-            score += max(Score.win + Int(timeRemaining * Score.multiplierFromTime) -
+            score += max(Score.win + Int(round(timeRemaining * Score.multiplierFromTime)) -
                 moves * Score.multiplierFromMoves, 0)
             gameStatus = .endedWithWon
         }


### PR DESCRIPTION
Previously when you play the grid games you see scores like `XXXX9`. This is because I used `Int(n)` and not `Int(round(n))` lol.