### PR TITLE
Aggressive Swap Tile Fix

### DIFF
--- a/Jasmine/Common/Constants.swift
+++ b/Jasmine/Common/Constants.swift
@@ -14,6 +14,8 @@ enum Constants {
 
         static let tilesFont = UIFont(name: "HelveticaNeue-Light", size: 30.0)
         static let cellsBackground = UIColor(hexString: "c2d1cc")
+
+        static let gridSnappingDuration = 0.2
     }
 
     enum Graphics {

--- a/Jasmine/Common/ViewControllers/SquareGrid/DraggableSquareGridViewController.swift
+++ b/Jasmine/Common/ViewControllers/SquareGrid/DraggableSquareGridViewController.swift
@@ -5,7 +5,7 @@ import UIKit
 class DraggableSquareGridViewController: SquareGridViewController {
 
     // MARK: Constants
-    private static let snappingDuration = 0.2
+    private static let snappingDuration = Constants.Theme.gridSnappingDuration
 
     // MARK: Properties
     /// Gets all the tiles in this collection view.

--- a/Jasmine/GameCommons/ViewControllers/SimpleStartGameViewController.swift
+++ b/Jasmine/GameCommons/ViewControllers/SimpleStartGameViewController.swift
@@ -40,5 +40,7 @@ class SimpleStartGameViewController: UIViewController {
     private func dismissView() {
         self.view.superview?.isHidden = true
         self.view.isHidden = true
+        self.view.superview?.isUserInteractionEnabled = false
+        self.view.isUserInteractionEnabled = false
     }
 }

--- a/Jasmine/Sliding/ViewControllers/SlidingGameViewController.swift
+++ b/Jasmine/Sliding/ViewControllers/SlidingGameViewController.swift
@@ -68,7 +68,6 @@ class SlidingGameViewController: UIViewController {
 
     /// Handles the gesture where the user drags the tile to an empty slot.
     @IBAction private func onTilesDragged(_ sender: UIPanGestureRecognizer) {
-        startGameIfPossible()
         guard viewModel.gameStatus == .inProgress else {
             return
         }
@@ -209,7 +208,6 @@ extension SlidingGameViewController: GameStatusUpdateDelegate {
             return
         }
         viewModel.startGame()
-        gameStartView.view.isHidden = true
     }
 }
 

--- a/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
+++ b/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
@@ -156,9 +156,9 @@ fileprivate extension SwappingGameViewController {
         guard let tile = draggingTile else {
             return
         }
+        self.draggingTile = nil
         squareGridViewController.snapDetachedTile(tile.view, toCoordinate: tile.originalCoord) {
             self.squareGridViewController.reattachDetachedTile(tile.view)
-            self.draggingTile = nil
         }
     }
 

--- a/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
+++ b/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
@@ -67,7 +67,6 @@ class SwappingGameViewController: UIViewController {
     ///
     /// Note that if the game status is not in progress, results in no-op.
     @IBAction private func onTilesDragged(_ sender: UIPanGestureRecognizer) {
-        startGameIfPossible()
         guard viewModel.gameStatus == .inProgress else {
             return
         }
@@ -208,7 +207,6 @@ extension SwappingGameViewController: GameStatusUpdateDelegate {
             return
         }
         viewModel.startGame()
-        gameStartView.view.isHidden = true
     }
 }
 

--- a/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
+++ b/Jasmine/Swapping/ViewControllers/SwappingGameViewController.swift
@@ -115,6 +115,7 @@ fileprivate extension SwappingGameViewController {
     /// - Parameter position: location where the tile is selected.
     fileprivate func handleTileSelected(at position: CGPoint) {
         guard draggingTile == nil,
+              squareGridViewController.detachedTiles.isEmpty,
               let coordTouched = squareGridViewController.getCoordinate(at: position),
               let detachedCell = squareGridViewController.detachTile(fromCoord: coordTouched) else {
             return

--- a/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
+++ b/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
@@ -99,7 +99,8 @@ class TetrisGameViewController: UIViewController {
     /// Switches the content of the falling tile with the latest upcoming tile when any tile in the
     /// list of upcoming tile is tapped.
     @IBAction private func onUpcomingTilesTouched(_ sender: UITapGestureRecognizer) {
-        guard tetrisGameAreaView.hasFallingTile,
+        guard viewModel.gameStatus == .inProgress,
+              tetrisGameAreaView.hasFallingTile,
               let coord = tetrisUpcomingTilesView
                   .getCoordinate(at: sender.location(in: tetrisUpcomingTilesView.view)) else {
             return
@@ -110,8 +111,8 @@ class TetrisGameViewController: UIViewController {
 
     /// Moves the falling tile when the view is swiped to a particular direction.
     @IBAction private func onTilesSwiped(_ sender: UISwipeGestureRecognizer) {
-        startGameIfPossible()
-        guard tetrisGameAreaView.hasFallingTile else {
+        guard viewModel.gameStatus == .inProgress,
+              tetrisGameAreaView.hasFallingTile else {
             return
         }
 
@@ -127,8 +128,8 @@ class TetrisGameViewController: UIViewController {
     /// Moves the falling tile with respect to the position of the falling tile when the user taps
     /// on the grid.
     @IBAction private func onTilesTapped(_ sender: UITapGestureRecognizer) {
-        startGameIfPossible()
-        guard let tileFrame = tetrisGameAreaView.fallingTile?.frame else {
+        guard viewModel.gameStatus == .inProgress,
+              let tileFrame = tetrisGameAreaView.fallingTile?.frame else {
             return
         }
 
@@ -298,7 +299,6 @@ extension TetrisGameViewController: GameStatusUpdateDelegate {
             return
         }
         viewModel.startGame()
-        gameStartView.view.isHidden = true
         tetrisGameAreaView.startFallingTiles(with: GameConstants.Tetris.tileFallInterval)
     }
 }


### PR DESCRIPTION
The bug is that when the tile is swapped too quickly, a tile may go under another tile.
This is caused when a tile returns to its own position, it can get repositioned, and swaps with another tile.