### PR TITLE
Animation Fix to Tetris

### DIFF
--- a/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
+++ b/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
@@ -85,8 +85,10 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
             return
         }
         self.fallingTile = nil
-        self.reattachDetachedTile(fallingTile, to: coordinate)
-        self.onFallingTileLanded?(coordinate)
+        self.snapDetachedTile(fallingTile, toCoordinate: coordinate) {
+            self.reattachDetachedTile(fallingTile, to: coordinate)
+            self.onFallingTileLanded?(coordinate)
+        }
     }
 
     // MARK: - Shifting Falling Tiles
@@ -97,17 +99,6 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
             return
         }
         snapDetachedTile(fallingTile, towards: direction) {
-            self.onFallingTileRepositioned?()
-        }
-    }
-
-    /// Shifts the falling tile to the specified coordinate.
-    /// - Parameter coordinate: the coordinate where the falling tile should shift to.
-    func shiftFallingTile(to coordinate: Coordinate) {
-        guard let fallingTile = fallingTile else {
-            return
-        }
-        snapDetachedTile(fallingTile, toCoordinate: coordinate) {
             self.onFallingTileRepositioned?()
         }
     }

--- a/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
+++ b/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
@@ -85,10 +85,8 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
             return
         }
         self.fallingTile = nil
-        snapDetachedTile(fallingTile, toCoordinate: coordinate) {
-            self.reattachDetachedTile(fallingTile)
-            self.onFallingTileLanded?(coordinate)
-        }
+        self.reattachDetachedTile(fallingTile, to: coordinate)
+        self.onFallingTileLanded?(coordinate)
     }
 
     // MARK: - Shifting Falling Tiles

--- a/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
+++ b/Jasmine/Common/ViewControllers/SquareGrid/DiscreteFallableSquareGridViewController.swift
@@ -13,9 +13,7 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
 
     // MARK: - Properties
     /// Gets the current falling tiles. Empty implies that no tile is falling currently.
-    var fallingTile: SquareTileView? {
-        return detachedTiles.first
-    }
+    var fallingTile: SquareTileView?
 
     /// Returns true if there is a falling tile.
     var hasFallingTile: Bool {
@@ -73,7 +71,8 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
         guard !hasFallingTile else {
             return
         }
-        guard addDetachedTile(withData: data, toCoord: coordinate) != nil else {
+        self.fallingTile = addDetachedTile(withData: data, toCoord: coordinate)
+        guard fallingTile != nil else {
             assertionFailure("A tile has failed to generate at \(coordinate)")
             return
         }
@@ -85,6 +84,7 @@ class DiscreteFallableSquareGridViewController: DraggableSquareGridViewControlle
         guard let fallingTile = fallingTile else {
             return
         }
+        self.fallingTile = nil
         snapDetachedTile(fallingTile, toCoordinate: coordinate) {
             self.reattachDetachedTile(fallingTile)
             self.onFallingTileLanded?(coordinate)

--- a/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
+++ b/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
@@ -238,6 +238,10 @@ extension TetrisGameViewController {
     fileprivate func animate(
         removeAll coords: [(destroyedTiles: Set<Coordinate>, shiftedTiles: [(from: Coordinate, to: Coordinate)])]) {
 
+        guard !coords.isEmpty else {
+            return
+        }
+
         var count = 0.0
         for (destroyedTiles, shiftedTiles) in coords {
             DispatchQueue.main
@@ -252,6 +256,11 @@ extension TetrisGameViewController {
                 }
             count += 1.0
         }
+
+        DispatchQueue.main
+            .asyncAfter(deadline: .now() + TetrisGameViewController.animationDelay * count) {
+                self.tetrisGameAreaView.reload(gridData: self.viewModel.gridData, withAnimation: true)
+            }
     }
 
     /// Ask the view controller to animate the destruction of tiles at the specified coordinates.

--- a/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
+++ b/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
@@ -170,7 +170,7 @@ class TetrisGameViewController: UIViewController {
             return
         }
         let finalCoord = viewModel.getLandingCoordinate(from: initCoord)
-        tetrisGameAreaView.shiftFallingTile(to: finalCoord)
+        tetrisGameAreaView.landFallingTile(at: finalCoord)
     }
 
     /// Updates the current falling tile and the upcoming tiles with new data.

--- a/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
+++ b/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
@@ -203,7 +203,7 @@ class TetrisGameViewController: UIViewController {
     /// Tells this view controller that the tile has landed successfully.
     private func notifyTileHasLanded(at coordinate: Coordinate) {
         let destroyedAndShiftedTiles = viewModel.landTile(at: coordinate)
-        animate(removeAll: destroyedAndShiftedTiles)
+        animate(removeAll: destroyedAndShiftedTiles, onComplete: nil)
         releaseNewTile()
     }
 
@@ -235,10 +235,13 @@ extension TetrisGameViewController {
     /// order as governed by the coords array.
     ///
     /// - Parameter coords: the list of coordinates to perform destroy and then shift in order.
+    /// - Parameter callback: the method that will be called when the animation ends.
     fileprivate func animate(
-        removeAll coords: [(destroyedTiles: Set<Coordinate>, shiftedTiles: [(from: Coordinate, to: Coordinate)])]) {
+        removeAll coords: [(destroyedTiles: Set<Coordinate>, shiftedTiles: [(from: Coordinate, to: Coordinate)])],
+        onComplete callback: (() -> Void)?) {
 
         guard !coords.isEmpty else {
+            callback?()
             return
         }
 
@@ -260,6 +263,7 @@ extension TetrisGameViewController {
         DispatchQueue.main
             .asyncAfter(deadline: .now() + TetrisGameViewController.animationDelay * count) {
                 self.tetrisGameAreaView.reload(gridData: self.viewModel.gridData, withAnimation: false)
+                callback?()
             }
     }
 

--- a/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
+++ b/Jasmine/Tetris/ViewControllers/TetrisGameViewController.swift
@@ -259,7 +259,7 @@ extension TetrisGameViewController {
 
         DispatchQueue.main
             .asyncAfter(deadline: .now() + TetrisGameViewController.animationDelay * count) {
-                self.tetrisGameAreaView.reload(gridData: self.viewModel.gridData, withAnimation: true)
+                self.tetrisGameAreaView.reload(gridData: self.viewModel.gridData, withAnimation: false)
             }
     }
 


### PR DESCRIPTION
Seems like it's a regression.
Fix details:
- DiscreteFallableSquareGridVC now stores which tile to fall, instead of assuming that the first detached tile is the tile to fall.
- After animation, a grid refresh will occur (unless a more sensible fix is found where tiles drops to ground before animation ends, which is rather complicated)

Edit:
- Tiles will lock immediately after landing, should not be able to shift left or right at all.