### PR TITLE
Added multi-select for phrase explorer

### DIFF
--- a/Jasmine/Common/ViewControllers/CommonsStoryboard.storyboard
+++ b/Jasmine/Common/ViewControllers/CommonsStoryboard.storyboard
@@ -57,7 +57,7 @@
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f9C-Gv-dVr">
                                 <rect key="frame" x="0.0" y="108" width="768" height="916"/>
                             </containerView>
-                            <view userInteractionEnabled="NO" alpha="0.10000000000000001" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QDF-T0-bV9">
+                            <view userInteractionEnabled="NO" alpha="0.20000000000000001" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QDF-T0-bV9">
                                 <rect key="frame" x="519" y="108" width="1" height="916"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>

--- a/Jasmine/Common/ViewControllers/CommonsStoryboard.storyboard
+++ b/Jasmine/Common/ViewControllers/CommonsStoryboard.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,11 +21,11 @@
                         <viewControllerLayoutGuide type="bottom" id="ncI-bH-3db"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="1mp-X2-ZcW">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fRz-oO-Zb3">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="64" id="Cix-Ii-6aI"/>
                                 </constraints>
@@ -48,15 +48,20 @@
                                 </items>
                             </navigationBar>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="SEARCH FOR PHRASE" translatesAutoresizingMaskIntoConstraints="NO" id="KVZ-Pg-UvA">
-                                <rect key="frame" x="0.0" y="64" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="64" width="768" height="44"/>
                                 <textInputTraits key="textInputTraits" returnKeyType="search"/>
                                 <connections>
                                     <outlet property="delegate" destination="PWD-mm-Vqa" id="U1X-SU-lHD"/>
                                 </connections>
                             </searchBar>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f9C-Gv-dVr">
-                                <rect key="frame" x="0.0" y="108" width="375" height="559"/>
+                                <rect key="frame" x="0.0" y="108" width="768" height="916"/>
                             </containerView>
+                            <view userInteractionEnabled="NO" alpha="0.10000000000000001" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QDF-T0-bV9">
+                                <rect key="frame" x="519" y="108" width="1" height="916"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -74,13 +79,14 @@
                     </view>
                     <connections>
                         <outlet property="explorerNavigationItem" destination="OHB-Pz-Qmo" id="Prt-RW-817"/>
+                        <outlet property="isScrollableDivider" destination="QDF-T0-bV9" id="p7b-Eh-E0Y"/>
                         <outlet property="navigationBar" destination="fRz-oO-Zb3" id="YZc-YH-oNP"/>
                         <outlet property="phrasesTableView" destination="f9C-Gv-dVr" id="Jxk-1k-Dd0"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jxV-6g-0cO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-463.19999999999999" y="120.98950524737631"/>
+            <point key="canvasLocation" x="-463.28125" y="120.70312499999999"/>
         </scene>
         <!--Phrase View Controller-->
         <scene sceneID="RRb-n2-vxW">
@@ -91,11 +97,11 @@
                         <viewControllerLayoutGuide type="bottom" id="ogM-Is-jRi"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="1U0-16-NkD">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kSs-Rg-kmX">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="64" id="NYK-u2-2at"/>
                                     <constraint firstAttribute="height" constant="64" id="ejU-eF-Hx1"/>
@@ -113,31 +119,31 @@
                                 </items>
                             </navigationBar>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="shi hou" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IIJ-bC-LHw">
-                                <rect key="frame" x="36" y="166" width="79" height="30"/>
+                                <rect key="frame" x="39" y="166" width="79" height="30"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="10" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUV-1w-24N">
-                                <rect key="frame" x="36" y="252" width="303" height="21"/>
+                                <rect key="frame" x="39" y="252" width="689" height="21"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="时候" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yys-DC-rDE">
-                                <rect key="frame" x="33" y="94" width="120.5" height="72"/>
+                                <rect key="frame" x="36" y="94" width="120.5" height="72"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="60"/>
                                 <color key="textColor" red="0.1819814891" green="0.69426733259999995" blue="0.53024792669999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENGLISH MEANING" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r7D-06-ny7">
-                                <rect key="frame" x="36" y="226" width="135" height="18"/>
+                                <rect key="frame" x="39" y="226" width="135" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.1819814891" green="0.69426733259999995" blue="0.53024792669999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BUP-VZ-TB2">
-                                <rect key="frame" x="161" y="131" width="30" height="30"/>
+                                <rect key="frame" x="164" y="131" width="30" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="30" id="Fjg-AQ-LSe"/>
                                     <constraint firstAttribute="width" secondItem="BUP-VZ-TB2" secondAttribute="height" multiplier="1:1" id="LQy-El-Sft"/>

--- a/Jasmine/Common/ViewControllers/PhrasesExplorerViewController.swift
+++ b/Jasmine/Common/ViewControllers/PhrasesExplorerViewController.swift
@@ -35,6 +35,7 @@ class PhrasesExplorerViewController: JasmineViewController {
         }
         isScrollableDivider.frame.origin.x = PhrasesSelectionTableViewController.scrollDividerBeforeRatio *
                                              phrasesTable.tableView.frame.maxX
+        isScrollableDivider.frame.size.height = phrasesTable.tableView.frame.size.height
     }
 
     /// Hides the save button on the navigation panel if not markable

--- a/Jasmine/Common/ViewControllers/PhrasesExplorerViewController.swift
+++ b/Jasmine/Common/ViewControllers/PhrasesExplorerViewController.swift
@@ -3,6 +3,7 @@ import SnapKit
 
 class PhrasesExplorerViewController: JasmineViewController {
 
+    @IBOutlet private var isScrollableDivider: UIView!
     @IBOutlet private var explorerNavigationItem: UINavigationItem!
     @IBOutlet private var phrasesTableView: UIView!
     @IBOutlet private weak var navigationBar: UINavigationBar!
@@ -22,6 +23,18 @@ class PhrasesExplorerViewController: JasmineViewController {
         setupPhrasesTable()
         searchController = UISearchController(searchResultsController: phrasesTable)
         showPhrasesTable()
+        setScrollableDivider()
+    }
+
+    /// Sets the position of the scrollable divider. Hide it if not selectable.
+    /// Regions before the divider will be scrollable and regions after the divider will be multi-select.
+    private func setScrollableDivider() {
+        guard onSaveCallBack != nil else {
+            isScrollableDivider.isHidden = true
+            return
+        }
+        isScrollableDivider.frame.origin.x = PhrasesSelectionTableViewController.scrollDividerBeforeRatio *
+                                             phrasesTable.tableView.frame.maxX
     }
 
     /// Hides the save button on the navigation panel if not markable

--- a/Jasmine/Common/ViewControllers/PhrasesSelectionTableViewController.swift
+++ b/Jasmine/Common/ViewControllers/PhrasesSelectionTableViewController.swift
@@ -1,13 +1,35 @@
 import UIKit
 
 class PhrasesSelectionTableViewController: PhrasesTableViewController {
+
+    /// Indicates from which portion of the screen should the scroll divider be at
+    static let scrollDividerBeforeRatio: CGFloat = 0.7
+    /// Indicates whether the pan gesture is currently selecting (as opposed to de-selecting) phrases.
+    /// Will be set to the opposite of whether the first phrase touched is selected.
+    /// This provides a more user-friendly and intuitive multi-selection gesture.
+    fileprivate var isSelecting: Bool?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setUpLongPressGesture()
+        setUpPanGesture()
+    }
+
+    private func setUpLongPressGesture() {
         let longPressGesture = UILongPressGestureRecognizer(target: self,
                                                             action: #selector(openPhraseInfo(sender:)))
         view.addGestureRecognizer(longPressGesture)
     }
+
+    @objc
+    private func openPhraseInfo(sender: UILongPressGestureRecognizer) {
+        guard let indexPath = tableView.indexPathForRow(at: sender.location(in: tableView)) else {
+            return
+        }
+        showPhraseView(phraseAt: indexPath)
+    }
+
     /// Executed when rows of the table is selected
     ///
     /// - Parameters:
@@ -18,11 +40,55 @@ class PhrasesSelectionTableViewController: PhrasesTableViewController {
         tableView.reloadRows(at: [indexPath], with: .none)
     }
 
+    private func setUpPanGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panHandler))
+        panGesture.delegate = self
+        tableView.addGestureRecognizer(panGesture)
+    }
+
+    /// Pan gesture handler for multi-select. 
+    /// Will proceed with multi-selection only if it is not in the scrolling region, 
+    /// otherwise will return and scrolling will be executed.
     @objc
-    private func openPhraseInfo(sender: UILongPressGestureRecognizer) {
-        guard let indexPath = tableView.indexPathForRow(at: sender.location(in: tableView)) else {
+    private func panHandler(_ recognizer: UIPanGestureRecognizer) {
+        let location = recognizer.location(in: tableView)
+        guard !isInScrollingRegion(location),
+              let indexPath = tableView.indexPathForRow(at: location) else {
             return
         }
-        showPhraseView(phraseAt: indexPath)
+        guard let isSelecting = isSelecting else {
+            assertionFailure("isSelecting is not set!")
+            return
+        }
+        if viewModel.toggle(at: indexPath.row, setToSelected: isSelecting) {
+            tableView.reloadRows(at: [indexPath], with: .none)
+        }
+    }
+
+    /// Returns if the location is within the scrolling region.
+    ///
+    /// - Parameter location: location of the gesture touch
+    /// - Returns: true if the ratio of the touch to the tableView is less than `scrollDividerBeforeRatio`
+    fileprivate func isInScrollingRegion(_ location: CGPoint) -> Bool {
+        return (location.x / tableView.bounds.maxX) < PhrasesSelectionTableViewController.scrollDividerBeforeRatio
+    }
+}
+
+extension PhrasesSelectionTableViewController: UIGestureRecognizerDelegate {
+    /// Activates scrolling only if location is in scrolling region
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        let location = gestureRecognizer.location(in: tableView)
+        return isInScrollingRegion(location)
+    }
+
+    /// Sets `isSelecting` based on whether the phrase first touched is selected
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        let location = gestureRecognizer.location(in: tableView)
+        guard let row = tableView.indexPathForRow(at: location)?.row else {
+            return true
+        }
+        isSelecting = !viewModel.get(at: row).selected
+        return true
     }
 }

--- a/Jasmine/Common/ViewModels/PhrasesExplorerViewModel.swift
+++ b/Jasmine/Common/ViewModels/PhrasesExplorerViewModel.swift
@@ -47,12 +47,25 @@ class PhrasesExplorerViewModel {
                 selected: phraseWithSelection.selected)
     }
 
+    /// Sets the phrase at `row` to `setToSelected`
+    ///
+    /// - Parameters:
+    ///   - row: the row to set
+    ///   - setToSelected: whether it should be set to selected
+    /// - Returns: true if toggled (original selection status is not equal to `setToSelected`)
+    @discardableResult func toggle(at row: Int, setToSelected: Bool) -> Bool {
+        let toggledIndex = rowIndices[row]
+        let isSelected = allPhrasesWithSelection[toggledIndex].selected
+        allPhrasesWithSelection[toggledIndex].selected = setToSelected
+        return isSelected != setToSelected
+    }
+
     /// Toggles the index given at the indices selected, i.e. remove if it exists, insert if not.
     ///
     /// - Parameter row: the row to be toggled
     func toggle(at row: Int) {
-        let toggledIndex = rowIndices[row]
-        allPhrasesWithSelection[toggledIndex].selected = !allPhrasesWithSelection[toggledIndex].selected
+        let isSelected = allPhrasesWithSelection[rowIndices[row]].selected
+        toggle(at: row, setToSelected: !isSelected)
     }
 
     /// Searches with the given keyword. Updates rowIndices


### PR DESCRIPTION
https://i.imgur.com/OlcCGrY.png

Regions before the grey divider will be scrollable and regions after the divider will be multi-select.
Position of the divider is set to a ratio (0.7 of the tableView frame currently).

If the phrase that is first touched by the pan gesture is originally marked, then the entire pan gesture will be de-marking phrases, otherwise the entire pan gesture will be marking phrases. (instead of merely toggling, makes it more user-friendly)

The divider will be hidden on non-selectable phrase explorer.

Note: if the scrolling is still decelerating, then panning the multi-select region will continue the scroll gesture instead of multi-selection. 